### PR TITLE
Ec 100532 improve mobile checkout ux

### DIFF
--- a/screen/store/components/ComponentsCheckout.js
+++ b/screen/store/components/ComponentsCheckout.js
@@ -75,6 +75,9 @@ storeComps.CheckOutPage = {
         productTotal: function () {
             return this.productsInCart.orderItemList ? this.getCartValueByItemEnum('ItemProduct') : 0;
         },
+        productCount: function(){
+            return this.productsInCart.orderItemList ? this.getCartCountByItemEnum('ItemProduct') : 0;
+        },
         //TODO Getting the applied promo codes should be done server-side
         appliedPromoCodes: function () {
             return this.productsInCart.orderItemList ?
@@ -104,6 +107,11 @@ storeComps.CheckOutPage = {
                 var value = c.itemTypeEnumId == itemEnum ? c.unitAmount * c.quantity : 0;
                 return a + value;
             }, 0);
+        },
+        getCartCountByItemEnum: function(itemEnum){
+            return this.productsInCart.orderItemList.reduce(function (acc, item) {
+                return item.itemTypeEnumId == itemEnum ? acc + item.quantity : acc + 0;
+            }, 0)
         },
         notAddressSeleted: function() {
             return (this.addressOption == null || this.addressOption == ''

--- a/screen/store/components/template/ModalAddress.html
+++ b/screen/store/components/template/ModalAddress.html
@@ -13,7 +13,7 @@
                     <div class="modal-body">
                         <!-- Recipient Field -->
                         <div class="form-group row justify-content-between">
-                            <label for="name" class="col-form-label modal-text ml-3">To<span>&nbsp;*</span></label>
+                            <label for="name" class="col-form-label modal-text ml-3">Name<span>&nbsp;*</span></label>
                             <div class="col-sm-8 col-xs-12">
                                 <input  id="name"
                                         class="form-control"
@@ -28,7 +28,7 @@
                         </div>
                         <!-- Attention Field-->
                         <div class="form-group row justify-content-between">
-                            <label for="attention" class="col-form-label modal-text ml-3">Attention of
+                            <label for="attention" class="col-form-label modal-text ml-3">Attention
                                 <small class="text-muted text-cyan">(Optional)</small>
                             </label>
                             <div class="col-sm-8 col-xs-12">
@@ -42,13 +42,12 @@
                         <div class="form-group row justify-content-between">
                             <label for="country" class="col-form-label modal-text ml-3">Country</label>
                             <div class="col-sm-8 col-xs-12">
-                                <select id="country"
+                                <input id="country"
+                                        type="hidden"
                                         v-model="shippingAddress.countryGeoId"
-                                        class="form-control"
                                         @change="getRegions(shippingAddress.countryGeoId)"
                                         @focus="resetCountryErrorMessage(shippingAddress.countryGeoId)">
-                                    <option value="USA" selected>United States</option>
-                                </select>
+                                <input class="form-control" type="text" value="United States" readonly/>
                                 <div v-if="countryErrorMessage != null && countryErrorMessage != ''">
                                     <small class="input-text form-text text-danger">{{countryErrorMessage}}</small>
                                 </div>
@@ -111,9 +110,9 @@
                                 </div>
                             </div>
                         </div>
-                        <!-- Postal code -->
+                        <!-- Zip/Postal code -->
                         <div class="form-group row justify-content-between">
-                            <label for="postalcode" class="col-form-label modal-text ml-3">Postcode<span>&nbsp;*</span></label>
+                            <label for="postalcode" class="col-form-label modal-text ml-3">{{shippingAddress.countryGeoId == 'USA' ? 'Zip Code' : 'Postal Code'}}<span>&nbsp;*</span></label>
                             <div class="col-sm-8 col-xs-12">
                                 <input id="postalcode"
                                        class="form-control"

--- a/screen/store/components/template/ModalCreditCard.html
+++ b/screen/store/components/template/ModalCreditCard.html
@@ -36,7 +36,7 @@
                             </div>
                             <div class="form-group row justify-content-between">
                                 <label class="col-form-label ml-3">
-                                    Expiry Date*
+                                    Expiration Date*
                                 </label>
                                 <div class="col-sm-8 col-xs-12 d-inline-flex">
                                     <select v-model="paymentMethod.expireMonth" class="form-control"
@@ -53,7 +53,7 @@
                                 </div>
                             </div>
                             <div class="form-group row justify-content-between" v-if="!isUpdate">
-                                <label class="col col-form-label">Select an Address*</label>
+                                <label class="col col-form-label">Select Billing Address*</label>
                                 <div class="col-12 col-sm-8">
                                     <select v-model="paymentAddressOption" class="form-control" 
                                         @change="selectBillingAddress(paymentAddressOption)">

--- a/screen/store/components/template/ModalCreditCard.html
+++ b/screen/store/components/template/ModalCreditCard.html
@@ -14,19 +14,20 @@
                                 class="alert alert-primary" role="alert"  v-html="responseMessage">
                             </div>
                             <div class="form-group row justify-content-between">
-                                <label for="nameCard" class="col-form-label modal-text ml-3">Name on Card</label>
-                                <div class="col-sm-8 col-xs-12">
+                                <label for="nameCard" class="col col-form-label modal-text">
+                                    Name on Card*
+                                </label>
+                                <div class="col-12 col-sm-8">
                                     <input class="form-control" id="nameCard"
                                         type="text" required
                                         v-model="paymentMethod.titleOnAccount"/>
                                 </div>
                             </div>
                             <div class="form-group row justify-content-between">
-                                <label for="card" class="col-form-label modal-text ml-3">
-                                    Card Number 
-                                    <span class="text-required">*</span>
+                                <label for="card" class="col col-form-label modal-text">
+                                    Card Number*
                                 </label>
-                                <div class="col-sm-8 col-xs-12">
+                                <div class="col-12 col-sm-8">
                                     <input class="form-control" id="card"
                                         type="text"
                                         v-model="paymentMethod.cardNumber"
@@ -34,7 +35,9 @@
                                 </div>
                             </div>
                             <div class="form-group row justify-content-between">
-                                <label class="col-form-label ml-3">Expiry Date</label>
+                                <label class="col-form-label ml-3">
+                                    Expiry Date*
+                                </label>
                                 <div class="col-sm-8 col-xs-12 d-inline-flex">
                                     <select v-model="paymentMethod.expireMonth" class="form-control"
                                         required>
@@ -50,8 +53,8 @@
                                 </div>
                             </div>
                             <div class="form-group row justify-content-between" v-if="!isUpdate">
-                                <label class="col-form-label ml-3">Select an Address*</label>
-                                <div class="col-sm-8 col-xs-12">
+                                <label class="col col-form-label">Select an Address*</label>
+                                <div class="col-12 col-sm-8">
                                     <select v-model="paymentAddressOption" class="form-control" 
                                         @change="selectBillingAddress(paymentAddressOption)">
                                         <option value="NEW_ADDRESS" >New Address</option>
@@ -136,12 +139,14 @@
                                     </div>
                                 </div>
                             </template>
-                            <div class="row justify-content-center button-spacing">
-                                <button type="submit" class="btn btn-info col-sm-6" :disabled='isDisabled'>
-                                    <span v-if="isUpdate">Update Card</span>
-                                    <span v-else>Add Card</span>
-                                </button>
-                                <a data-dismiss="modal" class="btn btn-link text-add col-sm-6">Cancel</a>
+                            <div class="container">
+                                <div class="row justify-content-center button-spacing">
+                                    <button type="submit" class="btn btn-info col-sm-6" :disabled='isDisabled'>
+                                        <span v-if="isUpdate">Update Card</span>
+                                        <span v-else>Add Card</span>
+                                    </button>
+                                    <a data-dismiss="modal" class="btn btn-link text-add col-sm-6">Cancel</a>
+                                </div>
                             </div>
                         </form>
                     </div>


### PR DESCRIPTION
- The text "Zip Code" is displayed instead of "Postal Code" if countryGeoId is equals to USA
- In the checkout component a computed property was added that returns the number of products in the shopping cart
- In the template of the modal window to add a new credit card, some labels were changed to be clearer
- In resolutions for mobile devices, the distribution of the elements of the modal to add credit cards was improved